### PR TITLE
chore: update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @camillemarini @ClementGautier
+* @AlexandrePicosson @AurelienGasser @Kelvin-M


### PR DESCRIPTION
Matching hlf-k8s ones